### PR TITLE
Demonstration randomness server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.env

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -17,12 +17,14 @@ criterion = "0.3.1"
 serde = "1.0.136"
 strobe-rs = "0.6.2"
 strobe-rng = { path = "../strobe-rng" }
+base64 = "0.13"
 
 [dev-dependencies]
 actix-web = "3.3.3"
 env_logger = "0.9.0"
 log = "0.4.14"
 reqwest = { version = "0.11.9", features = [ "blocking", "json" ] }
+dotenv = "0.15"
 
 [[bench]]
 name = "bench"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -12,8 +12,9 @@ rand_core = "0.6.2"
 rand_core_ristretto = { version="0.5.1", package="rand_core" }
 bitvec = "0.22.3"
 ring = "0.16.20"
-curve25519-dalek = "3.2.0"
+curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
 criterion = "0.3.1"
+serde = "1.0.136"
 strobe-rs = "0.6.2"
 strobe-rng = { path = "../strobe-rng" }
 

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -18,7 +18,9 @@ strobe-rs = "0.6.2"
 strobe-rng = { path = "../strobe-rng" }
 
 [dev-dependencies]
-actix-web = "4.0.0-rc.2"
+actix-web = "3.3.3"
+env_logger = "0.9.0"
+log = "0.4.14"
 
 [[bench]]
 name = "bench"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -22,6 +22,7 @@ strobe-rng = { path = "../strobe-rng" }
 actix-web = "3.3.3"
 env_logger = "0.9.0"
 log = "0.4.14"
+reqwest = { version = "0.11.9", features = [ "blocking" ] }
 
 [[bench]]
 name = "bench"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -22,7 +22,7 @@ strobe-rng = { path = "../strobe-rng" }
 actix-web = "3.3.3"
 env_logger = "0.9.0"
 log = "0.4.14"
-reqwest = { version = "0.11.9", features = [ "blocking" ] }
+reqwest = { version = "0.11.9", features = [ "blocking", "json" ] }
 
 [[bench]]
 name = "bench"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -17,6 +17,9 @@ criterion = "0.3.1"
 strobe-rs = "0.6.2"
 strobe-rng = { path = "../strobe-rng" }
 
+[dev-dependencies]
+actix-web = "4.0.0-rc.2"
+
 [[bench]]
 name = "bench"
 harness = false

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -21,6 +21,7 @@ base64 = "0.13"
 
 [dev-dependencies]
 actix-web = "3.3.3"
+base64 = "0.13.0"
 env_logger = "0.9.0"
 log = "0.4.14"
 reqwest = { version = "0.11.9", features = [ "blocking", "json" ] }

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -15,12 +15,12 @@
 
 use env_logger::Env;
 use log::info;
-use reqwest::blocking::get;
+use reqwest::blocking::{Client, get};
 
 /// Fetch the server identification string.
 ///
 /// Acts as a basic availability ping.
-fn fetch_id(url: &str) -> reqwest::Result<()> {
+fn fetch_ident(url: &str) -> reqwest::Result<()> {
     let res = get(url)?;
     let status = res.status();
     let text = res.text()?;
@@ -30,11 +30,32 @@ fn fetch_id(url: &str) -> reqwest::Result<()> {
     Ok(())
 }
 
+/// Fetch randomness from the server.
+///
+/// Acts as a basic round-trip test.
+fn fetch_randomness(url: &str) -> reqwest::Result<()> {
+    let client = Client::new();
+    let res = client.post(url)
+        .header("Content-Type", "application/json")
+        .body("{\"name\":\"example client\", \"points\": [
+                [226, 242, 174, 10, 106, 188, 78, 113,
+                 168, 132, 169, 97, 197, 0, 81, 95,
+                 88, 227, 11, 106, 165, 130, 221, 141,
+                 182, 166, 89, 69, 224, 141, 45, 118]]}")
+        .send()?;
+    let status = res.status();
+    let text = res.text()?;
+
+    info!("{} - {}", status, text);
+
+    Ok(())
+}
 fn main() {
     let url = "http://localhost:8080";
 
     env_logger::init_from_env(Env::default().default_filter_or("info"));
 
     info!("Contacting server at {}", url);
-    fetch_id(&url).unwrap();
+    fetch_ident(&url).unwrap();
+    fetch_randomness(&url).unwrap();
 }

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -1,0 +1,40 @@
+//! Example clieant for the ppoprf randomness web service.
+//!
+//! This tests and demonstrates the ppoprf evaluation function
+//! in an Actix-Web service application by making example queries.
+//!
+//! To verify the example works, start the server in one terminal:
+//! ```sh
+//! cargo run --example server
+//! ```
+//!
+//! In another terminal, launch the client:
+//! ```sh
+//! cargo run --example client
+//! ```
+
+use env_logger::Env;
+use log::info;
+use reqwest::blocking::get;
+
+/// Fetch the server identification string.
+///
+/// Acts as a basic availability ping.
+fn fetch_id(url: &str) -> reqwest::Result<()> {
+    let res = get(url)?;
+    let status = res.status();
+    let text = res.text()?;
+
+    info!("{} - {}", status, text);
+
+    Ok(())
+}
+
+fn main() {
+    let url = "http://localhost:8080";
+
+    env_logger::init_from_env(Env::default().default_filter_or("info"));
+
+    info!("Contacting server at {}", url);
+    fetch_id(&url).unwrap();
+}

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -36,7 +36,7 @@ fn fetch_ident(url: &str) -> reqwest::Result<()> {
 #[derive(Serialize)]
 struct Query {
     name: String,
-    points: Vec<Vec<u8>>,
+    points: Vec<String>,
 }
 
 /// Fetch randomness from the server.
@@ -45,7 +45,7 @@ struct Query {
 fn fetch_randomness(url: &str) -> reqwest::Result<()> {
     let query = Query {
         name: "example client".into(),
-        points: vec![ RISTRETTO_BASEPOINT_COMPRESSED.0.to_vec(), ],
+        points: vec![ base64::encode(RISTRETTO_BASEPOINT_COMPRESSED.0), ],
     };
     let client = Client::new();
     let res = client.post(url)

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -16,14 +16,14 @@
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use env_logger::Env;
 use log::info;
-use reqwest::blocking::{Client, get};
+use reqwest::blocking::Client as HttpClient;
 use serde::Serialize;
 
 /// Fetch the server identification string.
 ///
 /// Acts as a basic availability ping.
 fn fetch_ident(url: &str) -> reqwest::Result<()> {
-    let res = get(url)?;
+    let res = HttpClient::new().get(url).send()?;
     let status = res.status();
     let text = res.text()?;
 
@@ -47,8 +47,8 @@ fn fetch_randomness(url: &str) -> reqwest::Result<()> {
         name: "example client".into(),
         points: vec![ base64::encode(RISTRETTO_BASEPOINT_COMPRESSED.0), ],
     };
-    let client = Client::new();
-    let res = client.post(url)
+    let res = HttpClient::new()
+        .post(url)
         .json(&query)
         .send()?;
     let status = res.status();

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -13,11 +13,11 @@
 //! cargo run --example client
 //! ```
 
-use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use env_logger::Env;
 use log::info;
+use ppoprf::ppoprf;
 use reqwest::blocking::Client as HttpClient;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Fetch the server identification string.
 ///
@@ -36,25 +36,56 @@ fn fetch_ident(url: &str) -> reqwest::Result<()> {
 #[derive(Serialize)]
 struct Query {
     name: String,
-    points: Vec<String>,
+    points: Vec<ppoprf::Point>,
+}
+
+/// Explicit response body.
+#[derive(Deserialize)]
+struct Response {
+    name: String,
+    results: Vec<ppoprf::Evaluation>,
 }
 
 /// Fetch randomness from the server.
 ///
 /// Acts as a basic round-trip test.
 fn fetch_randomness(url: &str) -> reqwest::Result<()> {
+    // Construct a blinded message hash.
+    let message = "ppoprf test client";
+    let (blinded_message, r) = ppoprf::Client::blind(message.as_bytes());
+    // Submit it to the server.
     let query = Query {
         name: "example client".into(),
-        points: vec![ base64::encode(RISTRETTO_BASEPOINT_COMPRESSED.0), ],
+        points: vec![ blinded_message, ],
     };
     let res = HttpClient::new()
         .post(url)
         .json(&query)
         .send()?;
     let status = res.status();
-    let text = res.text()?;
+    let result = res.json::<Response>()?;
+    let results = result.results;
 
-    info!("{} - {}", status, text);
+    // We only submit one hash; confirm the server returned the same.
+    info!("{} {} - {} points returned", status, result.name, results.len());
+    assert_eq!(query.points.len(), results.len(),
+        "Server returned a different number of points!");
+    assert_eq!(results.len(), 1, "Expected one point!");
+    if let Some(result) = results.first() {
+        // Unblind the message hash.
+        let unblinded = ppoprf::Client::unblind(&result.output, &r);
+        // Next we would finalize the unblinded point to produce
+        // value needed for the next step of the Star protocol.
+        //
+        // This requires knowning the epoch metadata tag the server
+        // used, which we don't currently coordinate, so skip this step.
+        //let mut out = vec![0u8; ppoprf::COMPRESSED_POINT_LEN];
+        //ppoprf::Client::finalize(message.as_bytes(), &md, &unblinded, &mut out);
+        let point = base64::encode(&unblinded.as_bytes());
+        let proof = result.proof.is_some();
+        let meta = if proof { " proof" } else { "" };
+        info!("  {}{}", &point, &meta);
+    }
 
     Ok(())
 }

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -56,20 +56,25 @@ fn fetch_randomness(url: &str) -> reqwest::Result<()> {
     // Submit it to the server.
     let query = Query {
         name: "example client".into(),
-        points: vec![ blinded_message, ],
+        points: vec![blinded_message],
     };
-    let res = HttpClient::new()
-        .post(url)
-        .json(&query)
-        .send()?;
+    let res = HttpClient::new().post(url).json(&query).send()?;
     let status = res.status();
     let result = res.json::<Response>()?;
     let results = result.results;
 
     // We only submit one hash; confirm the server returned the same.
-    info!("{} {} - {} points returned", status, result.name, results.len());
-    assert_eq!(query.points.len(), results.len(),
-        "Server returned a different number of points!");
+    info!(
+        "{} {} - {} points returned",
+        status,
+        result.name,
+        results.len()
+    );
+    assert_eq!(
+        query.points.len(),
+        results.len(),
+        "Server returned a different number of points!"
+    );
     assert_eq!(results.len(), 1, "Expected one point!");
     if let Some(result) = results.first() {
         // Unblind the message hash.

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -19,28 +19,32 @@
 //! curl --silent localhost:8080 \
 //!     --header 'Content-Type: application/json' \
 //!     --data '{"name":"Nested STAR", "points": [
-//!         [226, 242, 174, 10, 106, 188, 78, 113,
-//!          168, 132, 169, 97, 197, 0, 81, 95,
-//!          88, 227, 11, 106, 165, 130, 221, 141,
-//!          182, 166, 89, 69, 224, 141, 45, 118]]}'
+//!         "4vKuCmq8TnGohKlhxQBRX1jjC2qlgt2NtqZZReCNLXY="
+//!         ]}'
 //! ```
 
 use actix_web::middleware::Logger;
 use actix_web::{get, post, web};
 use env_logger::Env;
+use dotenv::dotenv;
+use std::env;
 use log::info;
 
 use std::sync::{Arc, RwLock};
 
-use curve25519_dalek::ristretto::CompressedRistretto;
 use ppoprf::ppoprf;
 
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_EPOCH_DURATION: u64 = 5;
+const DEFAULT_MDS: &str = "116;117;118;119;120";
+const EPOCH_DURATION_ENV_KEY: &str = "EPOCH_DURATION";
+const MDS_ENV_KEY: &str = "METADATA_TAGS";
+
 #[derive(Deserialize)]
 struct EvalRequest {
     name: String,
-    points: Vec<CompressedRistretto>,
+    points: Vec<ppoprf::Point>,
 }
 
 #[derive(Serialize)]
@@ -49,7 +53,11 @@ struct EvalResponse {
     results: Vec<ppoprf::Evaluation>,
 }
 
-type State = Arc<RwLock<ppoprf::Server>>;
+struct ServerState {
+    prf_server: ppoprf::Server,
+    md_idx: usize
+}
+type State = Arc<RwLock<ServerState>>;
 
 #[get("/")]
 async fn index() -> &'static str {
@@ -65,12 +73,12 @@ async fn eval(
     state: web::Data<State>,
     data: web::Json<EvalRequest>,
 ) -> web::Json<EvalResponse> {
-    let server = state.read().unwrap();
+    let state = state.read().unwrap();
     // Pass each point from the client through the ppoprf.
     let result = data
         .points
         .iter()
-        .map(|p| server.eval(&p, 0, false))
+        .map(|p| state.prf_server.eval(&p, state.md_idx, false))
         .collect();
 
     // Return the results.
@@ -82,6 +90,8 @@ async fn eval(
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    dotenv().ok();
+
     let host = "localhost";
     let port = 8080;
 
@@ -89,27 +99,63 @@ async fn main() -> std::io::Result<()> {
     info!("Server configured on {} port {}", host, port);
 
     // Metadata tags marking each randomness epoch.
-    let test_mds = vec![vec!['t' as u8]];
+    let mds_str = match env::var(MDS_ENV_KEY) {
+        Ok(val) => {
+            val
+        },
+        Err(_) => {
+            info!("{} env var not defined, using default: {}",
+                MDS_ENV_KEY, DEFAULT_MDS);
+            DEFAULT_MDS.to_string()
+        }
+    };
+    let mds: Vec<Vec<u8>> = mds_str.split(';')
+        .map(|y| {
+            y.split(',').map(|x| {
+                x.parse().expect(
+                    "Could not parse metadata tags. Must contain 8-bit unsigned values!"
+                )
+            }).collect()
+        }).collect();
+
     // Time interval between puncturing each successive md.
-    let epoch = std::time::Duration::from_secs(5);
+    let epoch = std::time::Duration::from_secs(
+        match env::var(EPOCH_DURATION_ENV_KEY) {
+            Ok(val) => {
+                val.parse().expect(
+                    "Could not parse epoch duration. It must be a positive number!"
+                )
+            },
+            Err(_) => {
+                info!("{} env var not defined, using default: {} seconds",
+                    EPOCH_DURATION_ENV_KEY, DEFAULT_EPOCH_DURATION);
+                DEFAULT_EPOCH_DURATION
+            }
+        }
+    );
 
     // Shared actix webapp state cloned into each server thread.
     // We use an RWLock to handle the infrequent puncture events.
     // Only read access is necessary to answer queries.
-    let state = Arc::new(RwLock::new(ppoprf::Server::new(&test_mds)));
+    let state = Arc::new(RwLock::new(ServerState {
+        prf_server: ppoprf::Server::new(&mds),
+        md_idx: 0
+    }));
 
     // Spawn a background task.
     let background_state = state.clone();
     actix_web::rt::spawn(async move {
         log::info!("Spawned background epoch rotation task");
         // Wait for the end of an epoch.
-        actix_web::rt::time::delay_for(epoch).await;
-        if let Ok(mut server) = background_state.write() {
-            let md = &test_mds[0];
-            log::info!("Epoch rotation: puncturing '{:?}'", md);
-            server.puncture(md);
+        for md in &mds {
+            actix_web::rt::time::delay_for(epoch).await;
+            if let Ok(mut state) = background_state.write() {
+                log::info!("Epoch rotation: puncturing '{:?}'", md);
+                state.prf_server.puncture(md);
+                state.md_idx += 1;
+            }
+            log::info!("Epoch rotation complete");
         }
-        log::info!("Epoch rotation complete");
     });
 
     // Pass a factory closure to configure the server.

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -4,6 +4,9 @@
 /// service application so it can be accessed over https.
 
 use actix_web::{get, Responder};
+use actix_web::middleware::Logger;
+use env_logger::Env;
+use log::info;
 
 #[get("/")]
 async fn index() -> impl Responder {
@@ -17,9 +20,12 @@ async fn main() -> std::io::Result<()> {
     let host = "localhost";
     let port = 8080;
 
+    env_logger::init_from_env(Env::default().default_filter_or("info"));
+    info!("Server configured on {} port {}", host, port);
     actix_web::HttpServer::new(|| {
         actix_web::App::new()
             .service(index)
+            .wrap(Logger::default())
     })
     .bind((host, port as u16))?
     .run()

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -3,16 +3,48 @@
 /// This wraps the ppoprf evaluation function in an Actix-Web
 /// service application so it can be accessed over https.
 
-use actix_web::{get, Responder};
+use actix_web::{get, post, web};
 use actix_web::middleware::Logger;
 use env_logger::Env;
 use log::info;
 
+use curve25519_dalek::ristretto::CompressedRistretto;
+use ppoprf::ppoprf;
+
+use serde::{Serialize, Deserialize};
+
+#[derive(Deserialize)]
+struct EvalRequest {
+    name: String,
+    points: Vec<CompressedRistretto>,
+}
+
+#[derive(Serialize)]
+struct EvalResponse {
+    name: String,
+    results: Vec<ppoprf::Evaluation>,
+}
+
 #[get("/")]
-async fn index() -> impl Responder {
+async fn index() -> &'static str {
     // Simple string to identify the server.
     concat!("STAR protocol randomness server.\n",
         "See https://arxiv.org/abs/2109.10074 for more information.\n")
+}
+
+#[post("/")]
+async fn eval(server: web::Data<ppoprf::Server>, data: web::Json<EvalRequest>)
+        -> web::Json<EvalResponse> {
+    // Pass each point from the client through the ppoprf.
+    let result = data.points.iter()
+        .map(|p| server.eval(&p, 0, false))
+        .collect();
+
+    // Return the results.
+    web::Json(EvalResponse {
+        name: data.name.clone(),
+        results: result,
+    })
 }
 
 #[actix_web::main]
@@ -22,11 +54,23 @@ async fn main() -> std::io::Result<()> {
 
     env_logger::init_from_env(Env::default().default_filter_or("info"));
     info!("Server configured on {} port {}", host, port);
-    actix_web::HttpServer::new(|| {
+
+    // Actix webapp state cloned into each server thread.
+    let test_mds = vec![vec!['t' as u8]];
+    let server = ppoprf::Server::new(&test_mds);
+
+    // Pass a factory closure to configure the server.
+    actix_web::HttpServer::new(move || {
         actix_web::App::new()
+            // Register app state.
+            .data(server.clone())
+            // Register routes.
             .service(index)
+            .service(eval)
+            // Add logging and other middleware.
             .wrap(Logger::default())
     })
+    // Bind and start handling the requested address and port.
     .bind((host, port as u16))?
     .run()
     .await

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -25,15 +25,15 @@
 //!          182, 166, 89, 69, 224, 141, 45, 118]]}'
 //! ```
 
-use actix_web::{get, post, web};
 use actix_web::middleware::Logger;
+use actix_web::{get, post, web};
 use env_logger::Env;
 use log::info;
 
 use curve25519_dalek::ristretto::CompressedRistretto;
 use ppoprf::ppoprf;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 struct EvalRequest {
@@ -50,15 +50,21 @@ struct EvalResponse {
 #[get("/")]
 async fn index() -> &'static str {
     // Simple string to identify the server.
-    concat!("STAR protocol randomness server.\n",
-        "See https://arxiv.org/abs/2109.10074 for more information.\n")
+    concat!(
+        "STAR protocol randomness server.\n",
+        "See https://arxiv.org/abs/2109.10074 for more information.\n"
+    )
 }
 
 #[post("/")]
-async fn eval(server: web::Data<ppoprf::Server>, data: web::Json<EvalRequest>)
-        -> web::Json<EvalResponse> {
+async fn eval(
+    server: web::Data<ppoprf::Server>,
+    data: web::Json<EvalRequest>,
+) -> web::Json<EvalResponse> {
     // Pass each point from the client through the ppoprf.
-    let result = data.points.iter()
+    let result = data
+        .points
+        .iter()
         .map(|p| server.eval(&p, 0, false))
         .collect();
 

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -1,7 +1,29 @@
-/// Example ppoprf randomness web service.
-///
-/// This wraps the ppoprf evaluation function in an Actix-Web
-/// service application so it can be accessed over https.
+//! Example ppoprf randomness web service.
+//!
+//! This wraps the ppoprf evaluation function in an Actix-Web
+//! service application so it can be accessed over https.
+//!
+//! To verify the example works, start the server in one terminal:
+//! ```sh
+//! cargo run --example server
+//! ```
+//!
+//! In another terminal, verify the GET method returns a service
+//! identification:
+//! ```sh
+//! curl --silent localhost:8080
+//! ```
+//!
+//! Finally verify the POST method returns an altered point:
+//! ```sh
+//! curl --silent localhost:8080 \
+//!     --header 'Content-Type: application/json' \
+//!     --data '{"name":"Nested STAR", "points": [
+//!         [226, 242, 174, 10, 106, 188, 78, 113,
+//!          168, 132, 169, 97, 197, 0, 81, 95,
+//!          88, 227, 11, 106, 165, 130, 221, 141,
+//!          182, 166, 89, 69, 224, 141, 45, 118]]}'
+//! ```
 
 use actix_web::{get, post, web};
 use actix_web::middleware::Logger;

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -1,0 +1,27 @@
+/// Example ppoprf randomness web service.
+///
+/// This wraps the ppoprf evaluation function in an Actix-Web
+/// service application so it can be accessed over https.
+
+use actix_web::{get, Responder};
+
+#[get("/")]
+async fn index() -> impl Responder {
+    // Simple string to identify the server.
+    concat!("STAR protocol randomness server.\n",
+        "See https://arxiv.org/abs/2109.10074 for more information.\n")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let host = "localhost";
+    let port = 8080;
+
+    actix_web::HttpServer::new(|| {
+        actix_web::App::new()
+            .service(index)
+    })
+    .bind((host, port as u16))?
+    .run()
+    .await
+}

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -21,7 +21,7 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -21,8 +21,8 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 
+use serde::{de, ser, Deserialize, Serialize};
 use std::convert::TryInto;
-use serde::{Deserialize, Serialize, de, ser};
 
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
@@ -101,15 +101,20 @@ pub struct Point(
 );
 
 fn ristretto_serialize<S>(o: &CompressedRistretto, s: S) -> Result<S::Ok, S::Error>
-where S: ser::Serializer {
+where
+    S: ser::Serializer,
+{
     s.serialize_str(&base64::encode(o.0))
 }
 
 fn ristretto_deserialize<'de, D>(d: D) -> Result<CompressedRistretto, D::Error>
-where D: de::Deserializer<'de> {
+where
+    D: de::Deserializer<'de>,
+{
     let s: &str = de::Deserialize::deserialize(d)?;
     let data = base64::decode(s).map_err(de::Error::custom)?;
-    let fixed_data: [u8; 32] = data.try_into()
+    let fixed_data: [u8; 32] = data
+        .try_into()
         .map_err(|_| de::Error::custom("Ristretto must be 32 bytes"))?;
     Ok(CompressedRistretto(fixed_data))
 }

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -21,6 +21,8 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 
+use serde::{Serialize, Deserialize};
+
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
 
@@ -29,6 +31,7 @@ use crate::{ggm::GGM, PPRF};
 pub const COMPRESSED_POINT_LEN: usize = 32;
 pub const DIGEST_LEN: usize = 64;
 
+#[derive(Serialize, Deserialize)]
 pub struct ProofDLEQ {
     c: Scalar,
     s: Scalar,
@@ -81,6 +84,7 @@ impl ProofDLEQ {
 pub type ServerPublicKey = Vec<RistrettoPoint>;
 
 // The wrapper for PPOPRF evaluations (similar to standard OPRFs)
+#[derive(Serialize, Deserialize)]
 pub struct Evaluation {
     output: CompressedRistretto,
     proof: Option<ProofDLEQ>,

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -85,17 +85,19 @@ impl ProofDLEQ {
 pub type ServerPublicKey = Vec<RistrettoPoint>;
 
 // The wrapper for PPOPRF evaluations (similar to standard OPRFs)
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Evaluation {
+    #[serde(deserialize_with = "ristretto_deserialize")]
     #[serde(serialize_with = "ristretto_serialize")]
-    output: CompressedRistretto,
-    proof: Option<ProofDLEQ>,
+    pub output: CompressedRistretto,
+    pub proof: Option<ProofDLEQ>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Point(
     #[serde(deserialize_with = "ristretto_deserialize")]
-    CompressedRistretto
+    #[serde(serialize_with = "ristretto_serialize")]
+    CompressedRistretto,
 );
 
 fn ristretto_serialize<S>(o: &CompressedRistretto, s: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Add and example web service wrapper around the `ppoprf` implementation.

I mostly wrote this to develop my understanding of how the API should work. Corrections welcome!

- Starts a server and calls `eval` on a list of submitted points.
- Uses the default `Vec<u8>` serialization; `CompressedRistretto` should be a base64 string in json.
- I don't understand what the `mds` list should be, so I copied the single `t` from the unit tests.

To verify the example works, start the server in one terminal:
```sh
cd ppoprf
cargo run --example server
```
In another terminal, verify the GET method returns a service identification:
```sh
curl --silent localhost:8080
```
Finally verify the POST method returns an altered point:
 ```sh
curl --silent localhost:8080 \
    --header 'Content-Type: application/json' \
    --data '{"name":"Nested STAR", "points": [
        [226, 242, 174, 10, 106, 188, 78, 113,
         168, 132, 169, 97, 197, 0, 81, 95,
         88, 227, 11, 106, 165, 130, 221, 141,
         182, 166, 89, 69, 224, 141, 45, 118]]}'
```