### PR TITLE
Fix `cargo bench`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,6 @@
 on:
   push:
-    branches:
-    - main
   pull_request:
-    branches:
-    - main
 
 name: Tests
 

--- a/ppoprf/benches/bench.rs
+++ b/ppoprf/benches/bench.rs
@@ -7,7 +7,7 @@ use ring::digest;
 
 use ppoprf::ggm::GGM;
 use ppoprf::ppoprf::end_to_end_evaluation;
-use ppoprf::ppoprf::{Client, Server};
+use ppoprf::ppoprf::{Client, Point, Server};
 use ppoprf::PPRF;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -108,14 +108,16 @@ fn benchmark_server(c: &mut Criterion) {
     c.bench_function("Server eval", |b| {
         b.iter(|| {
             let server = Server::new(&mds);
-            server.eval(&RistrettoPoint::random(&mut OsRng).compress(), 0, false);
+            let point = Point(RistrettoPoint::random(&mut OsRng).compress());
+            server.eval(&point, 0, false);
         })
     });
 
     c.bench_function("Server verifiable eval", |b| {
         b.iter(|| {
             let server = Server::new(&mds);
-            server.eval(&RistrettoPoint::random(&mut OsRng).compress(), 0, true);
+            let point = Point(RistrettoPoint::random(&mut OsRng).compress());
+            server.eval(&point, 0, true);
         })
     });
 }
@@ -140,7 +142,7 @@ fn benchmark_client(c: &mut Criterion) {
         b.iter(|| {
             Client::verify(
                 &server.get_public_key(),
-                &blinded_point.decompress().unwrap(),
+                &blinded_point.0.decompress().unwrap(),
                 &eval,
                 0,
             );
@@ -150,7 +152,7 @@ fn benchmark_client(c: &mut Criterion) {
     c.bench_function("Client unblind", |b| {
         let (blinded_point, r) = Client::blind(input.as_ref());
         b.iter(|| {
-            Client::unblind(&blinded_point, &r);
+            Client::unblind(&blinded_point.0, &r);
         })
     });
 

--- a/ppoprf/examples/client.rs
+++ b/ppoprf/examples/client.rs
@@ -101,6 +101,6 @@ fn main() {
     env_logger::init_from_env(Env::default().default_filter_or("info"));
 
     info!("Contacting server at {}", url);
-    fetch_ident(&url).unwrap();
-    fetch_randomness(&url).unwrap();
+    fetch_ident(url).unwrap();
+    fetch_randomness(url).unwrap();
 }

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -75,7 +75,7 @@ async fn eval(state: web::Data<State>, data: web::Json<EvalRequest>) -> web::Jso
     let result = data
         .points
         .iter()
-        .map(|p| state.prf_server.eval(&p, state.md_idx, false))
+        .map(|p| state.prf_server.eval(p, state.md_idx, false))
         .collect();
 
     // Return the results.

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -97,7 +97,7 @@ pub struct Evaluation {
 pub struct Point(
     #[serde(deserialize_with = "ristretto_deserialize")]
     #[serde(serialize_with = "ristretto_serialize")]
-    CompressedRistretto,
+    pub CompressedRistretto,
 );
 
 fn ristretto_serialize<S>(o: &CompressedRistretto, s: S) -> Result<S::Ok, S::Error>

--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -1,3 +1,7 @@
+// Work around clippy warning from wasm_bidgen 0.2.79.
+// Can be removed after bumping to a release containing the upstream
+// fix in https://github.com/rustwasm/wasm-bindgen/pull/2778
+#![allow(clippy::unused_unit)]
 use wasm_bindgen::prelude::*;
 
 use base64::{decode, encode};


### PR DESCRIPTION
#13 failed to update the benchmark code for the `Client` api changes, breaking `cargo bench` and causing build failures in continuous integration.